### PR TITLE
Fix unused import warnings

### DIFF
--- a/rust_accumulator/src/lib.rs
+++ b/rust_accumulator/src/lib.rs
@@ -1,7 +1,5 @@
-use blstrs::{pairing, G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
+use blstrs::{G1Projective, G2Projective, Scalar};
 use ff::{Field, PrimeField};
-use group::prime::PrimeCurveAffine;
-use group::Group;
 use halo2_proofs::arithmetic::best_fft;
 
 /*


### PR DESCRIPTION
Fix generated by the command:
```
(cd rust_accumulator/ && cargo fix --lib -p rust_accumulator)
```